### PR TITLE
Correct Spring active profiles property name

### DIFF
--- a/rmap-installer/catalina.properties
+++ b/rmap-installer/catalina.properties
@@ -153,5 +153,5 @@ tomcat.util.buf.StringCache.byte.enabled=true
 
 # Added for RMap
 org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-spring.profiles.default=default,persistent-db,http-idservice,http-triplestore,persistent-userservice
+spring.profiles.active=default,persistent-db,http-idservice,http-triplestore,persistent-userservice
 rmap.configFile=file://RMAP_PROPS_FILE


### PR DESCRIPTION
After testing the production system, spring.profiles.active is a better property name for modifying the active profiles and this is only needed if the active profiles are different from the default ones. Updated catalina.properties with new property name.